### PR TITLE
Constant-time comparison on signature

### DIFF
--- a/1.HPP/SHA-256/check-payment-request-sha256.php
+++ b/1.HPP/SHA-256/check-payment-request-sha256.php
@@ -78,8 +78,8 @@
   // base64-encode the binary result of the HMAC computation
   $merchantSig = base64_encode(hash_hmac('sha256',$signData,pack("H*" , $hmacKey),true));
 
-  // Compare the calculated signature with the signature from the URL parameters
-  if ($merchantSig === $res_merchantSig)
+  // Constant-time comparison the calculated signature with the signature from the URL parameters
+  if (hash_equals($merchantSig, $res_merchantSig))
     print "Correct merchant signature";
   else
     print "Incorrect merchant signature";

--- a/1.HPP/SHA-256/check-payment-request-sha256.php
+++ b/1.HPP/SHA-256/check-payment-request-sha256.php
@@ -1,37 +1,40 @@
 <?php
 /**
  * HPP payment response url
- * 
- * Whenever a payment is made, the shopper is redirected either to a default 
- * or custom result page. Parameters are appended to this url to provide 
- * a status and general information about the payment.  
  *
- *  
- * @link	1.HPP/check-payment-response-sha256.php 
+ * Whenever a payment is made, the shopper is redirected either to a default
+ * or custom result page. Parameters are appended to this url to provide
+ * a status and general information about the payment.
+ *
+ *
+ * @link	1.HPP/check-payment-response-sha256.php
  * @author	Created by Adyen - Payments Made Easy
  */
- 
+
 /**
  * We recommend you to check the consistency of the URL parameters to ensure
  * that the data has not been tampered with, especially when you show
  * customer/order specific information on the result page, or make updates
  * to a back office system based on this data.
  * For this purpose, an HMAC is added to the query string parameters and can be
- * used to verify the data. The HMAC key which is set on the skin (used for 
+ * used to verify the data. The HMAC key which is set on the skin (used for
  * the initial payment request) is also used for the calculation of this result
  * URL parameter.
+ * The two HMAC's are then compared in constant-time to prevent timing attacks.
+ * Note that hash_equals is available from PHP >= 5.6.0. A secure polyfill can be
+ * found on https://github.com/sarciszewski/php-future/
  *
  * Note:
  * When special characters are returned in the url, PHP automatically replace
  * them with underscores such as dots.
  * In some use cases, additional data is returned in the URL and contain dots
  * such as additionalData.acquirerReference when using klarna. These special
- * characters must be taken as it is for the merchant signature calculation. 
+ * characters must be taken as it is for the merchant signature calculation.
  *
  */
 
-  $hmacKey = "[Your shared Hmac key]"; 
-  
+  $hmacKey = "[Your shared Hmac key]";
+
   /*
     Function definition
   */
@@ -75,11 +78,11 @@
   $signData = implode(":",array_map($escapeval,array_merge(array_keys($params),
     array_values($params))));
 
-  // base64-encode the binary result of the HMAC computation
-  $merchantSig = base64_encode(hash_hmac('sha256',$signData,pack("H*" , $hmacKey),true));
-
-  // Constant-time comparison the calculated signature with the signature from the URL parameters
-  if (hash_equals($merchantSig, $res_merchantSig))
+ /*
+   Base64-encode the binary result of the HMAC computation
+   Use constant-time comparison to compare the calculated signature with the signature from the URL parameters
+ */
+  if (hash_equals(base64_encode(hash_hmac('sha256', $signData, pack('H*', $hmacKey), true)), $res_merchantSig))
     print "Correct merchant signature";
   else
     print "Incorrect merchant signature";


### PR DESCRIPTION
Advise on using a constant-time comparison function when comparing the signatures to stop timing attacks.