### PR TITLE
Add CURLOPT_RETURNTRANSFER to curl request

### DIFF
--- a/6.PaymentMethods/get-payment-methods-SHA-256.php
+++ b/6.PaymentMethods/get-payment-methods-SHA-256.php
@@ -62,6 +62,7 @@ $request["merchantSig"] = $merchantSig;
  curl_setopt($ch, CURLOPT_HEADER, false);
  curl_setopt($ch, CURLOPT_POST,count($request));
  curl_setopt($ch, CURLOPT_POSTFIELDS,http_build_query($request));
+ curl_setopt($ch, CURLOPT_RETURNTRANSFER,true);
  
  $result = curl_exec($ch);
  


### PR DESCRIPTION
This returns the result into $result, rather than outputting it directly.