### PR TITLE
Update generate-payment-url-for-HPP-SHA256

### DIFF
--- a/1.HPP/SHA-256/generate-payment-url-for-HPP-SHA256
+++ b/1.HPP/SHA-256/generate-payment-url-for-HPP-SHA256
@@ -11,8 +11,8 @@
 *  $hmacKey:         the shared HMAC key.
 */   
 
-    $skinCode        = “yzrqpR13”; // your skinCode
-    $merchantAccount = “TestMerchant”; // your merchantAccount
+    $skinCode        = "yzrqpR13"; // your skinCode
+    $merchantAccount = "TestMerchant"; // your merchantAccount
     $hmacKey         = "BDF9B2857654743441D2EE15FB3EEEF2159227FE0D114C2CD31772D2785977DC"; // your HMAC Key
 
     
@@ -76,5 +76,5 @@
           $paymentUrl .= "&".$key."=".urlencode($value);
         }
     }
-    echo $paymentUrl;
+    echo htmlentities($paymentUrl);
 ?>


### PR DESCRIPTION
- 'htmlentities' will make sure that "&curren" will not be converted to the ¤ sign in cases where certain parameters are included in the payment request.
- Minor cleanup