### PR TITLE
Incorrect passing of variables to userAgent and acceptHeader in example.

### DIFF
--- a/2.API/JSON/create-3d-secure-payment.php
+++ b/2.API/JSON/create-3d-secure-payment.php
@@ -81,9 +81,9 @@ $request =array(
 		"number" => "5212345678901234",
 		"cvc" => "737"
 	),
-	"browserInfo"=>array(
-		"acceptHeader"=>$_SERVER['HTTP_USER_AGENT'],
-		"userAgent"=>$_SERVER['HTTP_ACCEPT']
+	"browserInfo" => array(
+		"acceptHeader" => $_SERVER['HTTP_ACCEPT'],
+		"userAgent" => $_SERVER['HTTP_USER_AGENT']
 	)
 );
  


### PR DESCRIPTION
Fixed: acceptHeader was being passed user agent and userAgent was being passed the accept header.